### PR TITLE
fix : examSubmissionTest의 optional에 의한 에러 수정 (#24)

### DIFF
--- a/Backend/src/test/java/site/devroad/softeer/src/test/ExamServiceTest.java
+++ b/Backend/src/test/java/site/devroad/softeer/src/test/ExamServiceTest.java
@@ -18,6 +18,8 @@ import site.devroad.softeer.src.user.UserRepo;
 import site.devroad.softeer.src.user.model.Account;
 import site.devroad.softeer.src.user.model.LoginInfo;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,7 +45,8 @@ class ExamServiceTest {
     void checkIfExamPassed() {
         //given
         LoginInfo loginInfo = userRepo.findLoginInfoByEmail("jm1234@naver.com").get();
-        Account account = userRepo.findAccountById(loginInfo.getAccountId());
+        Optional<Account> accountById = userRepo.findAccountById(loginInfo.getAccountId());
+        Account account = accountById.get();
 
         Subject subject = subjectRepo.findById(1L).get();
         //when


### PR DESCRIPTION
## WHAT?
- findAccountByID의 반환값이 Optional로 바뀐 것이 테스트코드에 반영되지 않아 테스트 실패가 발생함. 
- 따라서 관련된 테스트 코드를 수정함